### PR TITLE
Blacklisted PyQt5 as it causes a segmentation fault when indexing.

### DIFF
--- a/iresolve
+++ b/iresolve
@@ -13,6 +13,7 @@ from distutils import dir_util
 
 from pyflakes.api import checkPath
 
+MODULE_BLACKLIST = r'^PyQt5'
 
 class RReporter(object):
     messages = defaultdict(list)
@@ -59,7 +60,11 @@ def index_modules():
     suppress_output()
     modules = defaultdict(list)
     for modl, name, ispkg in pkgutil.walk_packages(onerror=lambda x: True):
-        path = os.path.join(modl.path, name.split('.')[-1])
+        try:
+            path = os.path.join(modl.path, name.split('.')[-1])
+        except AttributeError:
+            # Triggered on zipimport.zipimporter
+            continue
 
         if os.path.isdir(path):
             path = os.path.join(path, '__init__')
@@ -76,12 +81,14 @@ def index_modules():
                                         for expr in exprs] if r for k in r]
             except:
                 continue
-        else:
+        elif not re.search(MODULE_BLACKLIST, name):
             try:
                 mod = __import__(name)
                 objs = [k for k in dir(mod) if not k.startswith('__')]
             except:
                 continue
+        else:
+            continue
 
         for obj in objs:
             if name not in modules[obj]:

--- a/iresolve
+++ b/iresolve
@@ -8,6 +8,8 @@ import os.path
 import pkgutil
 import re
 import sys
+import fnmatch
+
 from collections import defaultdict
 from distutils import dir_util
 
@@ -53,13 +55,25 @@ def get_unresolved_variables(f):
     return dict(reporter.messages)
 
 
-def index_modules():
+def read_objs_from_path(path):
+    with open(path) as f:
+        exprs = [r'^def (\w+)', r'^class (\w+)', r'^(\w+) =']
+        data = f.read()
+        objs = [k for r in [re.findall(expr, data, flags=re.MULTILINE)
+                            for expr in exprs] if r for k in r]
+    return objs
+
+
+def index_modules(idx=None, path=None):
     """
     Indexes objs from all modules
     """
     suppress_output()
     modules = defaultdict(list)
-    for modl, name, ispkg in pkgutil.walk_packages(onerror=lambda x: True):
+    pkglist = pkgutil.walk_packages(onerror=lambda x: True)
+    if path:
+        pkglist = pkgutil.walk_packages(path, onerror=lambda x: True)
+    for modl, name, ispkg in pkglist:
         try:
             path = os.path.join(modl.path, name.split('.')[-1])
         except AttributeError:
@@ -74,11 +88,7 @@ def index_modules():
 
         if os.path.exists(path):
             try:
-                with open(path) as f:
-                    exprs = [r'^def (\w+)', r'^class (\w+)', r'^(\w+) =']
-                    data = f.read()
-                    objs = [k for r in [re.findall(expr, data, flags=re.MULTILINE)
-                                        for expr in exprs] if r for k in r]
+                objs = read_objs_from_path(path)
             except:
                 continue
         elif not re.search(MODULE_BLACKLIST, name):
@@ -94,8 +104,20 @@ def index_modules():
             if name not in modules[obj]:
                 modules[obj].append(name)
     suppress_output(True)
-    return dict(modules)
+    return merge_dicts(idx, dict(modules))
 
+
+def merge_dicts(d1, d2):
+    if not d1:
+        return d2
+    for v in d2:
+        if v in d1:
+            for kv in d2[v]:
+                if kv not in d1[v]:
+                    d1[v].append(kv)
+        else:
+            d1[v] = d2[v]
+    return d1
 
 def get_suggestions(idx, unresolved):
     """
@@ -116,8 +138,26 @@ def output(results, output_format='pretty'):
     elif output_format == 'json':
         print(json.dumps(results))
 
-if __name__ == "__main__":
+def get_local_config(parsed):
+    dirname = os.path.dirname(parsed.input)
+    while os.path.dirname(dirname) != dirname:
+        if os.path.exists(os.path.join(dirname, 'iresolve.json')):
+            with open(os.path.join(dirname, 'iresolve.json'), 'r') as f:
+                config_data = json.loads(f.read())
+            if 'path' in config_data:
+                original_paths = parsed.path.split(',') if parsed.path else []
+                paths = config_data['path'].split(',')
+                for path in paths:
+                    if path[0] != '/' and path[0] != '\\':
+                        original_paths.append(os.path.join(dirname, path))
+                    else:
+                        original_paths.append(path)
+                parsed.path = ','.join(original_paths)
+            break
+        dirname = os.path.dirname(dirname)
+    return parsed
 
+if __name__ == "__main__":
     import argparse
 
     default_cache = os.path.join(os.path.expanduser('~'), '.cache/iresolve')
@@ -126,9 +166,13 @@ if __name__ == "__main__":
     ap.add_argument('--format', choices=['pretty', 'json'], default='pretty', help='Export format')
     ap.add_argument('--cache', default=default_cache, help='Path to cache location')
     ap.add_argument('--index', action='store_true', help='(Re)generate module index')
+    ap.add_argument('--path', help='Consider additional paths')
     parsed = ap.parse_args()
 
     u = get_unresolved_variables(parsed.input)
+
+    # See if there's a local configuration
+    parsed = get_local_config(parsed)
 
     # module cache
     modidx = os.path.realpath(os.path.join(parsed.cache, 'modules.json'))
@@ -141,6 +185,12 @@ if __name__ == "__main__":
     else:
         with open(modidx) as f:
             idx = json.loads(f.read())
+
+    if parsed.path:
+        paths = parsed.path.split(',')
+        for path in paths:
+            sys.path.append(path)
+        idx = index_modules(idx)
 
     results = get_suggestions(idx, u)
     output(results, parsed.format)


### PR DESCRIPTION
This _may_ resolve the Segmentation Fault issue (Issue #3) or at least help solve it.

I encountered the segfault problem on Python 3 on Linux (Ubuntu) when it tried to index the PyQt5 module.  Was able to get around it by implementing a blacklist .. obviously not ideal as it prevents imports being resolved to that particular module, but should provide a quick fix until the issue can be properly investigated and resolved.

This PR also catches an error thrown when trying to index zipimport
